### PR TITLE
Properly close fileoutput stream

### DIFF
--- a/src/main/java/rocks/kavin/reqwest4j/ReqwestUtils.java
+++ b/src/main/java/rocks/kavin/reqwest4j/ReqwestUtils.java
@@ -41,8 +41,8 @@ public class ReqwestUtils {
 
         final var cl = ReqwestUtils.class.getClassLoader();
 
-        try (var stream = cl.getResourceAsStream("META-INF/natives/" + native_folder + "/" + arch + "/libreqwest" + extension)) {
-            stream.transferTo(new FileOutputStream(nativeFile));
+        try (var stream = cl.getResourceAsStream("META-INF/natives/" + native_folder + "/" + arch + "/libreqwest" + extension); var fileOutputStream = new FileOutputStream(nativeFile)) {
+            stream.transferTo(fileOutputStream);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This was causing an error on windows before with
```
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.UnsatisfiedLinkError: R:\Temp\libreqwest3363153669421833704.dll: The process cannot access the file because it is being used by another process [in thread "main"]
```